### PR TITLE
fixed postcode issue with leading 0

### DIFF
--- a/app/src/main/java/org/woheller69/spritpreise/api/tankerkoenig/TKDataExtractor.java
+++ b/app/src/main/java/org/woheller69/spritpreise/api/tankerkoenig/TKDataExtractor.java
@@ -58,7 +58,7 @@ public class TKDataExtractor implements IDataExtractor {
             if (json.getString("brand").equals("")) station.setBrand(json.getString("name"));
             station.setName(json.getString("name"));
             station.setAddress1(json.getString("street")+" "+json.getString("houseNumber"));
-            station.setAddress2(json.getString("postCode") +" "+json.getString("place"));
+            station.setAddress2(formatPostCode(json.getString("postCode")) +" "+json.getString("place"));
             station.setDistance(json.getDouble("dist"));
             station.setLatitude(json.getDouble("lat"));
             station.setLongitude(json.getDouble("lng"));
@@ -71,4 +71,8 @@ public class TKDataExtractor implements IDataExtractor {
         return null;
     }
 
+    public static String formatPostCode(String string) {
+        // Adds a leading 0 to the postcode string if needed
+        return string.length() == 4 ? ("0" + string) : string;
+    }
 }


### PR DESCRIPTION
In eastern Germany are many postcodes which start with a leading zero. The Tankerkoenig API provides the postcodes as Integer and therefore these codes aren´t dispayed correctly. This PR adds a function to concat a 0 to the postcode-string if needed.

before:
![Screenshot_20220920-011529_Spritpreise (2)](https://user-images.githubusercontent.com/28687460/191135911-35ec5f03-31ca-44b5-b516-14da420c12ec.png)

after:
![Screenshot_20220920-011432_Spritpreise (2)](https://user-images.githubusercontent.com/28687460/191136073-1b7acffe-29e0-4716-8f63-f667eb1903dc.png)

